### PR TITLE
👍 Gloomrot update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,61 @@
+name: Build
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  build:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: 6.0.x
+
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Install GitVersion
+        uses: gittools/actions/gitversion/setup@v0.9.7
+        with:
+          versionSpec: "5.x"
+
+      - name: Determine Version
+        uses: gittools/actions/gitversion/execute@v0.9.7
+        with:
+          additionalArguments: '/updateprojectfiles /overrideconfig "mode=Mainline"'
+
+      - name: Build (Release)
+        run: dotnet build serverlaunchfix --configuration Release -p:Version=$GitVersion_SemVer
+
+      - name: Run Unit Tests
+        run: dotnet test
+      
+      - name: Upload a Build Artifact
+        if: ${{ !env.ACT }}
+        uses: actions/upload-artifact@v3.1.0
+        with:
+          path: ./serverlaunchfix/bin/Release/net6.0/serverlaunchfix.dll
+        
+      - name: GH Release
+        uses: softprops/action-gh-release@v1
+        if:  ${{ !env.ACT && github.event_name == 'push' }}
+        with:
+          body: Automatic pre-release of ${{ env.GitVersion_SemVer }} for ${{ env.GitVersion_ShortSha }}
+          name: v${{ env.GitVersion_SemVer }}
+          files: ./serverlaunchfix/bin/Release/net6.0/serverlaunchfix.dll
+          fail_on_unmatched_files: true
+          prerelease: true
+          tag_name: v${{ env.GitVersion_SemVer }}

--- a/ServerLaunchFix/NuGet.Config
+++ b/ServerLaunchFix/NuGet.Config
@@ -2,5 +2,6 @@
 <configuration>
   <packageSources>
     <add key="BepInEx" value="https://nuget.bepinex.dev/v3/index.json" />
+    <add key="Samboy Feed" value="https://nuget.samboy.dev/v3/index.json" />
   </packageSources>
 </configuration>

--- a/ServerLaunchFix/Plugin.cs
+++ b/ServerLaunchFix/Plugin.cs
@@ -8,6 +8,7 @@ using BepInEx.IL2CPP;
 using UnityEngine;
 using HarmonyLib;
 using ProjectM.Shared;
+using BepInEx.Unity.IL2CPP;
 
 namespace ServerLaunchFix
 {
@@ -48,24 +49,54 @@ namespace ServerLaunchFix
         }
 
         private const string DoorstopConfig = @"
-[UnityDoorstop]
-# Specifies whether assembly executing is enabled
-enabled=true
-# Specifies the path (absolute, or relative to the game's exe) to the DLL/EXE that should be executed by Doorstop
-targetAssembly=BepInEx\core\BepInEx.IL2CPP.dll
-# Specifies whether Unity's output log should be redirected to <current folder>\output_log.txt
-redirectOutputLog=false
+# General options for Unity Doorstop
+[General]
 
-[MonoBackend]
-runtimeLib=..\mono\MonoBleedingEdge\EmbedRuntime\mono-2.0-sgen.dll
-configDir=..\mono\MonoBleedingEdge\etc
-corlibDir=..\mono\Managed
-# Specifies whether the mono soft debugger is enabled
-debugEnabled=false
-# Specifies whether the mono soft debugger should suspend the process and wait for the remote debugger
-debugSuspend=false
-# Specifies the listening address the soft debugger
-debugAddress=127.0.0.1:10000
+# Enable Doorstop?
+enabled = true
+
+# Path to the assembly to load and execute
+# NOTE: The entrypoint must be of format `static void Doorstop.Entrypoint.Start()`
+target_assembly = BepInEx\core\BepInEx.Unity.IL2CPP.dll
+
+# If true, Unity's output log is redirected to <current folder>\output_log.txt
+redirect_output_log = false
+
+# If enabled, DOORSTOP_DISABLE env var value is ignored
+# USE THIS ONLY WHEN ASKED TO OR YOU KNOW WHAT THIS MEANS
+ignore_disable_switch = false
+
+# Options specific to running under Unity Mono runtime
+[UnityMono]
+
+# Overrides default Mono DLL search path
+# Sometimes it is needed to instruct Mono to seek its assemblies from a different path
+# (e.g. mscorlib is stripped in original game)
+# This option causes Mono to seek mscorlib and core libraries from a different folder before Managed
+# Original Managed folder is added as a secondary folder in the search path
+dll_search_path_override =
+
+# If true, Mono debugger server will be enabled
+debug_enabled = false
+
+# When debug_enabled is true, this option specifies whether Doorstop should initialize the debugger server
+# If you experience crashes when starting the debugger on debug UnityPlayer builds, try setting this to false
+debug_start_server = true
+
+# When debug_enabled is true, specifies the address to use for the debugger server
+debug_address = 127.0.0.1:10000
+
+# If true and debug_enabled is true, Mono debugger server will suspend the game execution until a debugger is attached
+debug_suspend = false
+
+# Options sepcific to running under Il2Cpp runtime
+[Il2Cpp]
+
+# Path to coreclr.dll that contains the CoreCLR runtime
+coreclr_path = ..\dotnet\coreclr.dll
+
+# Path to the directory containing the managed core libraries for CoreCLR (mscorlib, System, etc.)
+corlib_dir = ..\dotnet
 ";
         private const string BepInExConfig = @"
 [Logging.Console]
@@ -124,7 +155,7 @@ Enabled = false
             {
                 var name = Path.GetFileName(entry);
                 var destination = Path.Combine(serverBepInExDir, name);
-                if (name is "cache" or "config" or "unhollowed")
+                if (name is "cache" or "config" or "interop")
                 {
                     RecursiveCopyIfNewer(entry, destination);
                 }
@@ -135,7 +166,7 @@ Enabled = false
             }
 
             File.WriteAllText(Path.Combine(serverBepInExDir, "config", "BepInEx.cfg"), BepInExConfig);
-            return Path.Combine(serverBepInExDir, "core", "BepInEx.IL2CPP.dll");
+            return Path.Combine(serverBepInExDir, "core", "BepInEx.Unity.IL2CPP.dll");
         }
 
         private static void RecursiveCopyIfNewer(string source, string destination)
@@ -187,7 +218,7 @@ Enabled = false
             var doorstopTarget = PrepareServerBepInEx();
             if (doorstopTarget != null)
             {
-                return $" --doorstop-enable true --doorstop-target \"{doorstopTarget}\"";
+                return $" --doorstop-enable true --doorstop-target-assembly \"{doorstopTarget}\"";
             }
 
             return "";

--- a/ServerLaunchFix/ServerLaunchFix.csproj
+++ b/ServerLaunchFix/ServerLaunchFix.csproj
@@ -14,6 +14,6 @@
         <PackageReference Include="BepInEx.Unity.IL2CPP" Version="6.0.0-be*" IncludeAssets="compile" />
         <PackageReference Include="BepInEx.Core" Version="6.0.0-be*" IncludeAssets="compile" />
         <PackageReference Include="BepInEx.PluginInfoProps" Version="1.*" />
-        <PackageReference Include="VRising.Unhollowed.Client" Version="0.6.0.57108*" />
+        <PackageReference Include="VRising.Unhollowed.Client" Version="0.6.5.57575071" />
     </ItemGroup>
 </Project>

--- a/ServerLaunchFix/ServerLaunchFix.csproj
+++ b/ServerLaunchFix/ServerLaunchFix.csproj
@@ -1,33 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <AssemblyName>ServerLaunchFix</AssemblyName>
         <BepInExPluginGuid>dev.mythic.vrising.serverlaunchfix</BepInExPluginGuid>
         <Description>Enables server-side mods when launching the built-in server.</Description>
-        <Version>0.1.0</Version>
+        <Version>0.2.0</Version>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
 
-    <Import Project="Config.xml" />
-
     <ItemGroup>
-        <PackageReference Include="BepInEx.IL2CPP" Version="6.0.0-*" IncludeAssets="compile" />
+        <PackageReference Include="BepInEx.Unity.IL2CPP" Version="6.0.0-be*" IncludeAssets="compile" />
+        <PackageReference Include="BepInEx.Core" Version="6.0.0-be*" IncludeAssets="compile" />
         <PackageReference Include="BepInEx.PluginInfoProps" Version="1.*" />
-    </ItemGroup>
-
-    <ItemGroup>
-        <Reference Include="IL2Cppmscorlib">
-            <HintPath>$(UnhollowedDllPath)\Il2Cppmscorlib.dll</HintPath>
-        </Reference>
-
-        <Reference Include="ProjectM.Shared">
-            <HintPath>$(UnhollowedDllPath)\ProjectM.Shared.dll</HintPath>
-        </Reference>
-
-        <Reference Include="UnityEngine.CoreModule">
-            <HintPath>$(UnhollowedDllPath)\UnityEngine.CoreModule.dll</HintPath>
-        </Reference>
+        <PackageReference Include="VRising.Unhollowed.Client" Version="0.6.0.57108*" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary of changes
- `net6.0`
- Use nuget gamelibs for build
- Remove `Config.xml`
- New BepInEx 6 `dotnet` and `interop` paths, and update namespaces
- Critically `-doorstop-target` -> `-doorstop-target-assembly`
- Version -> `0.2.0`